### PR TITLE
Changed AMD detection to follow standard approach

### DIFF
--- a/cyclone.js
+++ b/cyclone.js
@@ -321,7 +321,7 @@
   if (typeof module === 'object' && typeof module.exports === 'object') {
     // Node
     module.exports = CY;
-  } else if (_isFunc(define) && _isFunc(require)) {
+  } else if (typeof define === "function" && define.amd) {
     // AMD/RequireJS
     define([], function() { return CY; });
   } else {


### PR DESCRIPTION
The AMD spec only requires loaders to implement `define` (`require` is actually not an official part of the spec), and the standard way to detect for an AMD loader is to check for `typeof define === "function" && define.amd`. The current AMD detection will throw a reference error if that branch is selected in the if/else due to `define` not actually being defined. This PR should take care of that issue. Please let me know if you need anything else from my end. Glad you put this together!
