### PR TITLE
Fixes #28: Swap new Array() for literal constructor

### DIFF
--- a/cyclone.js
+++ b/cyclone.js
@@ -185,7 +185,7 @@
         break;
 
       case '[object Array]':
-        output = new Array(input.length);
+        output = [];
         isCollection = true;
         break;
 


### PR DESCRIPTION
See #28 for more details. Speeds up the cloning of small arrays by an order of magnitude.